### PR TITLE
Remove m-mask support and legacy netmask support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Can also match an IP address search term against firewall
 configuration with netmasks.
 
     $ ipgrep 4.3.2.1 example.conf
-    allow all from 4.3.2.1m255.255.255.0
-    deny from 4.3.2.1m31
+    allow all from 4.3.2.1/24
+    deny from 4.3.2.1/31
 
 [![Go](https://github.com/joneskoo/ipgrep/workflows/Go/badge.svg)](https://github.com/joneskoo/ipgrep/actions?query=workflow%3AGo)
 
@@ -17,7 +17,6 @@ Supported formats:
  * 1.2.3.4 (plain IPv4)
  * 1.2.3.4/24 (IPv4 CIDR)
  * 1.2.3.4m24 (IPv4 m notation)
- * 1.2.3.4m255.255.255.0 (IPv4 m mask)
  * 2001:db8::1 (plain IPv6)
  * 2001:db8::1/64 (IPv6 CIDR)
 

--- a/ipgrep_test.go
+++ b/ipgrep_test.go
@@ -95,30 +95,6 @@ func TestIpgrep(t *testing.T) {
 			want:    "",
 		},
 		{
-			name:    "no match IPv4 m netmask with specific IPv4",
-			pattern: "1.2.2.4",
-			input:   "1.2.3.4m255.255.255.0\n",
-			want:    "",
-		},
-		{
-			name:    "match IPv4 m netmask with specific IPv4",
-			pattern: "1.2.3.4",
-			input:   "1.2.3.4m255.255.255.0\n",
-			want:    "1.2.3.4m255.255.255.0\n",
-		},
-		{
-			name:    "match IPv4 m netmask with IPv4 in prefix",
-			pattern: "1.2.3.4",
-			input:   "1.2.3.0m255.255.255.0\n",
-			want:    "1.2.3.0m255.255.255.0\n",
-		},
-		{
-			name:    "match IPv4 slash netmask with IPv4 in prefix",
-			pattern: "1.2.3.4",
-			input:   "1.2.3.0/255.255.255.0\n",
-			want:    "1.2.3.0/255.255.255.0\n",
-		},
-		{
 			name:    "match IPv6 with IPv6",
 			pattern: "2001:db8::1",
 			input:   "2001:db8::1\n",
@@ -141,18 +117,6 @@ func TestIpgrep(t *testing.T) {
 			name:    "no match IPv4 CIDR with specific IPv4",
 			pattern: "1.2.3.4",
 			input:   "1.2.2.4/24\n",
-			want:    "",
-		},
-		{
-			name:    "no match IPv4 m CIDR with specific IPv4",
-			pattern: "1.2.2.4",
-			input:   "1.2.3.4m24\n",
-			want:    "",
-		},
-		{
-			name:    "no match IPv4 m netmask with specific IPv4",
-			pattern: "1.2.2.4",
-			input:   "1.2.3.4m255.255.255.0\n",
 			want:    "",
 		},
 		{
@@ -181,21 +145,6 @@ func TestIpgrep(t *testing.T) {
 				t.Errorf("wanted Grep(%q) to write %q, got %q", c.input, c.want, got)
 			}
 		})
-	}
-}
-
-func BenchmarkGrepMMask(b *testing.B) {
-	b.ReportAllocs()
-	input, err := ioutil.ReadFile("README.md")
-	if err != nil {
-		b.Errorf("Failed to read README.md: %v", err)
-	}
-	for i := 0; i < b.N; i++ {
-		br := bytes.NewReader(input)
-		err := ipgrep.Grep(br, ioutil.Discard, "1.2.3.4m255.255.255.0")
-		if err != nil {
-			b.Errorf("Grep failed unexpectedly: %v", err)
-		}
 	}
 }
 


### PR DESCRIPTION
I'm not sure how useful the m syntax for netmask and legacy /255.255.255.0 format are… removing them would clean up this much code.